### PR TITLE
fix inconsistent phone number structure in footer

### DIFF
--- a/layouts/index-constrained.html
+++ b/layouts/index-constrained.html
@@ -578,7 +578,7 @@
 							</p>
 						</div>
 						<p class="mt-3 mb-0">
-							Phone: <a href="tel:xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
+							Phone: <a href="tel:+1-xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
 						</p>
 					</div>
 				</div>

--- a/layouts/index-drk-full.html
+++ b/layouts/index-drk-full.html
@@ -451,7 +451,7 @@
 							</p>
 						</div>
 						<p class="mt-3 mb-0">
-							Phone: <a href="tel:xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
+							Phone: <a href="tel:+1-xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
 						</p>
 					</div>
 				</div>

--- a/layouts/index-galleries.html
+++ b/layouts/index-galleries.html
@@ -445,7 +445,7 @@
 							</p>
 						</div>
 						<p>
-							Phone: <a href="tel:xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
+							Phone: <a href="tel:+1-xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
 						</p>
 					</div>
 				</div>

--- a/layouts/index-menu-in-header.html
+++ b/layouts/index-menu-in-header.html
@@ -551,7 +551,7 @@
 							</p>
 						</div>
 						<p class="mt-3 mb-0">
-							Phone: <a href="tel:xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
+							Phone: <a href="tel:+1-xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
 						</p>
 					</div>
 				</div>

--- a/layouts/index-sidebar.html
+++ b/layouts/index-sidebar.html
@@ -494,7 +494,7 @@
 							</p>
 						</div>
 						<p class="mt-3 mb-0">
-							Phone: <a href="tel:xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
+							Phone: <a href="tel:+1-xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
 						</p>
 					</div>
 				</div>

--- a/layouts/index-tester-navigation.html
+++ b/layouts/index-tester-navigation.html
@@ -452,7 +452,7 @@
 							</p>
 						</div>
 						<p>
-						Phone: <a href="tel:xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
+						Phone: <a href="tel:+1-xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
 						</p>
 					</div>
 				</div>

--- a/layouts/ipp.html
+++ b/layouts/ipp.html
@@ -493,7 +493,7 @@
 							</p>
 						</div>
 						<p>
-							Phone: <a href="tel:xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
+							Phone: <a href="tel:+1-xxx-xxx-xxxx" itemprop="telephone">xxx-xxx-xxxx</a>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
All phone numbers have a pre-set +1 country code except this one. Now that's fixed.