### PR TITLE
Max width removal from breadcrumbs

### DIFF
--- a/layouts/css/site-theme/_breadcrumbs.scss
+++ b/layouts/css/site-theme/_breadcrumbs.scss
@@ -41,7 +41,6 @@
 	color:$gray-600;
 	font-size:0.9rem;
 	display:inline-block;
-	max-width:200px;
 	text-overflow:ellipsis;
 	overflow:hidden;
 	white-space:no-wrap;


### PR DESCRIPTION
Breadcrumb items shouldn't have a max width. Overflow causes the divider to move out of place.