### PR TITLE
Removes Vestigial Variable

### DIFF
--- a/blank-layout/styles/_variables.scss
+++ b/blank-layout/styles/_variables.scss
@@ -11,9 +11,6 @@ $color-third: map-get($theme-colors, "tertiary");
 // Enable rounded?
 $enable-rounded: false;
 
-// Enable Bootstrap 4.3's responsive font sizes
-$enable-responsive-font-sizes: true;
-
 // Border classes width
 $theme-borders-width: 2px;
 


### PR DESCRIPTION
In Bootstrap 5, font sizes are responsive by default