### PR TITLE
Removes iOS Phone Number Changes

### DIFF
--- a/blank-layout/index.html
+++ b/blank-layout/index.html
@@ -5,7 +5,6 @@
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta property="og:type" content="website" />
 	<meta itemprop="logo" content="<?= $baseUrl ?>/images/logo.png">
-	<meta name="format-detection" content="telephone=no">
 
 	<link href="favicon.ico" rel="shortcut icon" type="image/x-icon">
 	<link href="favicon.ico" rel="icon" type="image/x-icon">

--- a/blank-layout/styles/_defaults.scss
+++ b/blank-layout/styles/_defaults.scss
@@ -9,10 +9,6 @@ $font-third:  Roboto-Regular, sans-serif;
 * {
     white-space: normal;
 }
-a[href^=tel] {
-    text-decoration: none;
-    color: inherit;
-}
 a {
     cursor: pointer;
     color: map-get($theme-colors, "secondary");


### PR DESCRIPTION
If Safari wants to overwrite phone numbers and their styling, we're not going to bother with changing it on every site for every browser