### PR TITLE
Favicon should only be 1 call and use png

### DIFF
--- a/blank-layout/index.html
+++ b/blank-layout/index.html
@@ -6,8 +6,7 @@
 	<meta property="og:type" content="website" />
 	<meta itemprop="logo" content="<?= $baseUrl ?>/images/logo.png">
 
-	<link href="favicon.ico" rel="shortcut icon" type="image/x-icon">
-	<link href="favicon.ico" rel="icon" type="image/x-icon">
+	<link href="images/favicon.png" rel="icon" type="image/png">
 	<link href="styles/theme.css" rel="stylesheet" type="text/css">
 
 	<script defer src="styles/dependencies/bootstrap/js/bootstrap.bundle.min.js" type="text/javascript"></script>


### PR DESCRIPTION
There's no reason to have 2 favicon calls.

Also, since we haven't supported internet explorer in a long time, we should use the png format.