### PR TITLE
Bootstrap Buttons Sizing Fix

### DIFF
--- a/components/buttons/Buttons 1 - Default/_btns.scss
+++ b/components/buttons/Buttons 1 - Default/_btns.scss
@@ -1,6 +1,9 @@
+.btn:not(.btn-sm, .btn-lg) {
+	padding: 0.75rem 1.5rem;
+	font-size: 0.9rem;
+}
+
 .btn {
 	font-family: $font-second;
-	font-size: 0.9rem;
 	text-transform: uppercase;
-	padding: 0.75rem 1.5rem;
 }

--- a/components/buttons/Buttons 2 - Primary Font/_btns.scss
+++ b/components/buttons/Buttons 2 - Primary Font/_btns.scss
@@ -1,6 +1,9 @@
+.btn:not(.btn-sm, .btn-lg) {
+	padding: 0.75rem 1.5rem;
+	font-size: 0.9rem;
+}
+
 .btn {
 	font-family: $font-prime;
-	font-size: 0.9rem;
 	text-transform: uppercase;
-	padding: 0.75rem 1.5rem;
 }

--- a/components/buttons/Buttons 3 - Rounded/_btns.scss
+++ b/components/buttons/Buttons 3 - Rounded/_btns.scss
@@ -1,7 +1,10 @@
+.btn:not(.btn-sm, .btn-lg) {
+	padding: 0.75rem 1.5rem;
+	font-size: 0.9rem;
+}
+
 .btn {
 	font-family: $font-prime;
-	font-size: 0.9rem;
 	text-transform: uppercase;
-	padding: 0.75rem 1.5rem;
 	border-radius: 10rem;
 }


### PR DESCRIPTION
Currently you cannot use `.btn-sm` or `.btn-lg`, This CSS Correction makes utilizing the Bootstrap button sizes `.btn-sm` / `.btn-lg` possible again.

I have tested it on a few of my recent sites and it seems to work as expected: 
![image](https://user-images.githubusercontent.com/41697893/168899151-03f7c59d-9207-444c-aac5-a332fbcfb062.png)
