### PR TITLE
Invalid HTML fix

### DIFF
--- a/components/map-section/Map Section 1 - Default/index.html
+++ b/components/map-section/Map Section 1 - Default/index.html
@@ -5,6 +5,6 @@
 			Our Service Area
 		</h2>
 	</div>
-	<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d110078.9825937864!2d-87.26278386335376!3d30.43700321032621!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8890bf45accbaabb%3A0xa7c69a6e3179657c!2sPensacola%2C%20FL!5e0!3m2!1sen!2sus!4v1614719463617!5m2!1sen!2sus" class="p-0" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+	<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d110078.9825937864!2d-87.26278386335376!3d30.43700321032621!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8890bf45accbaabb%3A0xa7c69a6e3179657c!2sPensacola%2C%20FL!5e0!3m2!1sen!2sus!4v1614719463617!5m2!1sen!2sus" class="p-0" style="border:0;width:100%;height:450px;" allowfullscreen="" loading="lazy"></iframe>
 </section>
 <!-- END MAP SECTION -->


### PR DESCRIPTION
- Using percentages for width or height in attributes is not valid HTML. This should be set in styles.
- Using pixel values for html is valid, but moving it to style as well to keep both values in one place.